### PR TITLE
Set up frontend/backend testing on Travis CI.  Resolves #21.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,22 +7,23 @@ otp_release:
   - 20.0.4
 
 before_install:
+  # for e2e testing using Chrome and Selenium
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+  # install and use latest NodeJS LTS release
   - nvm install --lts
   - nvm use --lts
+  # install frontend dependencies
   - cd frontend
   - npm install
   - cd ..
 
-# before_script:
-#   - jdk_switcher use oraclejdk8
-
 script:
+  # test backend
   - mix test
+  # test frontend
   - cd frontend
-  - npm run unit
-  - npm run e2e
+  - npm run test
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ branches:
   only:
     - master
     - develop
-    - temp/setup-travis
 
 addons:
   chrome: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ elixir:
 otp_release:
   - 20.0.4
 
-# sudo: required
-# dist: trusty
-
 before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
@@ -18,8 +15,8 @@ before_install:
   - npm install
   - cd ..
 
-before_script:
-  - jdk_switcher use oraclejdk8
+# before_script:
+#   - jdk_switcher use oraclejdk8
 
 script:
   - mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: elixir
+
+elixir:
+  - 1.5.1
+
+otp_release:
+  - 20.0.4
+
+pre_install:
+  - nvm install --lts
+  - nvm use --lts
+  - cd frontend
+  - npm install
+
+script:
+  - mix test
+  - cd frontend
+  - npm run unit
+  - npm run e2e
+
+branches:
+  only:
+    - master
+    - develop
+    - temp/setup-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,12 @@ elixir:
 otp_release:
   - 20.0.4
 
-sudo: required
-dist: trusty
+# sudo: required
+# dist: trusty
 
 before_install:
-  # - export CHROME_BIN=/usr/bin/google-chrome
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  # - sudo apt-get update
-  # - sudo apt-get install -y libappindicator1 fonts-liberation
-  # - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-  # - sudo dpkg -i google-chrome*.deb
   - nvm install --lts
   - nvm use --lts
   - cd frontend

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
   - nvm use --lts
   - cd frontend
   - npm install
+  - cd ..
 
 script:
   - mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ elixir:
 otp_release:
   - 20.0.4
 
-pre_install:
+before_install:
   - nvm install --lts
   - nvm use --lts
   - cd frontend

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,13 @@ sudo: required
 dist: trusty
 
 before_install:
-  - export CHROME_BIN=/usr/bin/google-chrome
+  # - export CHROME_BIN=/usr/bin/google-chrome
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - sudo apt-get update
-  - sudo apt-get install -y libappindicator1 fonts-liberation
-  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-  - sudo dpkg -i google-chrome*.deb
+  # - sudo apt-get update
+  # - sudo apt-get install -y libappindicator1 fonts-liberation
+  # - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+  # - sudo dpkg -i google-chrome*.deb
   - nvm install --lts
   - nvm use --lts
   - cd frontend
@@ -37,3 +37,6 @@ branches:
     - master
     - develop
     - temp/setup-travis
+
+addons:
+  chrome: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,30 @@
 language: elixir
+
 elixir:
   - 1.5.1
+
 otp_release:
   - 20.0.4
 
+sudo: required
+dist: trusty
+
 before_install:
+  - export CHROME_BIN=/usr/bin/google-chrome
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+  - sudo apt-get update
+  - sudo apt-get install -y libappindicator1 fonts-liberation
+  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+  - sudo dpkg -i google-chrome*.deb
   - nvm install --lts
   - nvm use --lts
   - cd frontend
   - npm install
   - cd ..
+
+before_script:
+  - jdk_switcher use oraclejdk8
 
 script:
   - mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: elixir
-
 elixir:
   - 1.5.1
-
 otp_release:
   - 20.0.4
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Parcel
+# Parcel [![Build Status](https://travis-ci.org/code-for-nashville/parcel.svg?branch=temp%2Fsetup-travis)](https://travis-ci.org/code-for-nashville/parcel)
 
 Answering your Nashville, TN acceptable land use questions.
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ To build and run this app locally:
 - Install the Mix dependencies `mix deps.get`.
 - Compile the project `mix compile`.
 - Run the Phoenix server `mix phx.server`.
-- Install the frontend dependencies `cd frontend && npm install`.
-- Run the frontend's HTTP server `cd frontend && npm run dev`.
+- Navigate to frontend app `cd frontend`.
+- Install the NPM dependencies `npm install`.
+- Run the frontend's HTTP server `npm run dev`.
 
 _Note: Additional commands are available for the frontend app and are documented in its [README](frontend)._
 
@@ -27,6 +28,19 @@ To build and run this app for production:
 - Compile the project `mix compile`.
 - Build and copy the frontend app to the Phoenix server `mix parcel.prepare_static_assets`.
 - Run the Phoenix server `mix phx.server`.
+
+## Testing
+To test the backend:
+- Install the Mix dependencies `mix deps.get`.
+- Compile the project `mix compile`.
+- Run tests `mix test`.
+
+To test the frontend:
+- Navigate to frontend app `cd frontend`.
+- Install the NPM dependencies `npm install`.
+- Run the unit tests `npm run unit`.
+- Run the end-to-end tests `npm run e2e`.
+- Run the unit and end-to-end tests `npm run test`.
 
 ## Planning
 - For a detailed description of the project, check out the [Request for Volunteers](https://docs.google.com/document/d/17DNk0QQyi8SEK4utcMt3zT-Dc6vXzA_zcFwrEENvKJo/edit?usp=sharing).

--- a/test/parcel_web/controllers/page_controller_test.exs
+++ b/test/parcel_web/controllers/page_controller_test.exs
@@ -1,8 +1,0 @@
-defmodule ParcelWeb.PageControllerTest do
-  use ParcelWeb.ConnCase
-
-  test "GET /", %{conn: conn} do
-    conn = get conn, "/"
-    assert html_response(conn, 200) =~ "Welcome to Phoenix!"
-  end
-end


### PR DESCRIPTION
Set up Travis CI to run:
- Backend Elixir/Phoenix app tests.
- Frontend VueJS/JS tests.
- Frontend VueJS/JS tests on Chrome using Selenium and Nightwatch.