### PR TITLE
Cache Elixir and frontend Node directories.  Closes #34.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: elixir
 
 elixir:
-  - 1.5.1
+  - 1.5.2
 
 otp_release:
-  - 20.0.4
+  - 20.1.3
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ elixir:
 otp_release:
   - 20.0.4
 
+cache:
+  directories:
+    - _build
+    - deps
+    - frontend/node_modules
+
 before_install:
   # for e2e testing using Chrome and Selenium
   - export DISPLAY=:99.0


### PR DESCRIPTION
Elixir directories: `_build` and `deps`
Node directory: `node_modules`

Bump Elixir and Erlang/OTP versions to `1.5.2` and `20.1.3` respectively.