### PR TITLE
Quick endpoints with canned results - need more thought and error handling

### DIFF
--- a/lib/parcel_web/controllers/land_use_categories_controller.ex
+++ b/lib/parcel_web/controllers/land_use_categories_controller.ex
@@ -1,0 +1,27 @@
+defmodule ParcelWeb.LandUseCategoriesController do
+  use ParcelWeb, :controller
+
+  action_fallback ParcelWeb.FallbackController
+
+  def canned_result do
+    [
+      %{"id" => 1, "name" => "Residential Uses"},
+      %{"id" => 2, "name" => "Institutional Uses"},
+      %{"id" => 3, "name" => "Educational Uses"},
+      %{"id" => 4, "name" => "Office Uses"},
+      %{"id" => 5, "name" => "Medical Uses"},
+      %{"id" => 6, "name" => "Commercial Uses"},
+      %{"id" => 7, "name" => "Communication Uses"},
+      %{"id" => 8, "name" => "Industrial Uses"},
+      %{"id" => 9, "name" => "Transportation Uses"},
+      %{"id" => 10, "name" => "Utility Uses"},
+      %{"id" => 11, "name" => "Waste Management Uses"},
+      %{"id" => 12, "name" => "Recreation and Entertainment Uses"},
+      %{"id" => 13, "name" => "Other Uses"}
+    ]
+  end
+
+  def index(conn, _params) do
+    render(conn, "index.json", land_use_categories: canned_result)
+  end
+end

--- a/lib/parcel_web/controllers/land_uses_controller.ex
+++ b/lib/parcel_web/controllers/land_uses_controller.ex
@@ -1,0 +1,36 @@
+defmodule ParcelWeb.LandUsesController do
+  use ParcelWeb, :controller
+
+  def canned_result do
+    %{
+      "zone" => %{
+        "code" => "RS40",
+        "description" => "Small houses for families",
+        "category" => "Residential",
+      },
+      "land_uses" => [
+        %{
+          "category" => "Residential",
+          "description" => "Build a house for your family less than 40K sqft",
+          "condition_code" => "P"  # Permitted by right
+        },
+        %{
+          "category" => "Residential",
+          "description" => "Build a house for your family larger than 40K sqft",
+          "condition_code" => "NP"  # Not permitted
+        },
+        %{
+          "category" => "Industrial",
+          "description" => "Build a warehouse",
+          "condition_code" => "NP"
+        }
+      ]
+    }
+  end
+
+  def index(conn, %{"address" => address}) do
+    render(conn, "index.json", land_uses_report: canned_result)
+  end
+
+  def index(_conn, _params), do: { :error,  :bad_request, "Missing address parameter."}
+end

--- a/lib/parcel_web/router.ex
+++ b/lib/parcel_web/router.ex
@@ -15,6 +15,11 @@ defmodule ParcelWeb.Router do
 
   scope "/api", ParcelWeb do
     pipe_through :api
+
+    # /landuses has a required "address" query param
+    get "/landuses", LandUsesController, :index
+
+    get "/landusecategories", LandUseCategoriesController, :index
   end
 
   scope "/", ParcelWeb do

--- a/lib/parcel_web/views/land_use_categories_view.ex
+++ b/lib/parcel_web/views/land_use_categories_view.ex
@@ -1,0 +1,7 @@
+defmodule ParcelWeb.LandUseCategoriesView do
+  use ParcelWeb, :view
+
+  def render("index.json", %{land_use_categories: categories}) do
+    categories
+  end
+end

--- a/lib/parcel_web/views/land_uses_view.ex
+++ b/lib/parcel_web/views/land_uses_view.ex
@@ -1,0 +1,7 @@
+defmodule ParcelWeb.LandUsesView do
+  use ParcelWeb, :view
+
+  def render("index.json", %{land_uses_report: land_uses_report}) do
+    land_uses_report
+  end
+end

--- a/test/parcel_web/controllers/land_use_categories_controller_test.exs
+++ b/test/parcel_web/controllers/land_use_categories_controller_test.exs
@@ -1,0 +1,13 @@
+defmodule ParcelWeb.LandUseCategoriesControllerTest do
+  use ParcelWeb.ConnCase
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  test "Returns canned results", %{conn: conn} do
+    conn = get(conn, "/api/landusecategories")
+
+    assert json_response(conn, 200) == ParcelWeb.LandUseCategoriesController.canned_result
+  end
+end

--- a/test/parcel_web/controllers/land_uses_controler_test.exs
+++ b/test/parcel_web/controllers/land_uses_controler_test.exs
@@ -1,0 +1,14 @@
+defmodule ParcelWeb.LandUsesControllerTest do
+  use ParcelWeb.ConnCase
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  test "Returns canned results", %{conn: conn} do
+    params = [address: "500 Interstate Blvd S, Suite 300"]
+    conn = get(conn, "/api/landuses", params)
+
+    assert json_response(conn, 200) == ParcelWeb.LandUsesController.canned_result
+  end
+end


### PR DESCRIPTION
This mocks out the `/api/landusecategories` and `/api/landuses`