### PR TITLE
Use intended use endpoint - yay!

### DIFF
--- a/frontend/src/api/parcelApiClient.js
+++ b/frontend/src/api/parcelApiClient.js
@@ -10,7 +10,7 @@ class ParcelApiClient {
   }
 
   getAllIntendedUses () {
-    return this.client.get('/intended-uses')
+    return this.client.get('/landusecategories')
   }
 
 /* /landuses/?address="My Addresss" - Return an object:

--- a/frontend/src/store/modules/intendedUses.js
+++ b/frontend/src/store/modules/intendedUses.js
@@ -12,16 +12,8 @@ export const getters = {
 
 export const actions = {
   fetchAllIntendedUses ({ commit }) {
-    const mockUses = [
-      'party',
-      'party',
-      'join us',
-      'join us'
-    ]
-
-    commit(types.GET_INTENDED_USES_SUCCESS, mockUses)
-
-    return mockUses
+    return ParcelApiClient.getAllIntendedUses()
+      .then(resp => commit(types.GET_INTENDED_USES_SUCCESS, resp.data))
   },
 
   fetchUsesForAddress ({ commit }, address) {


### PR DESCRIPTION
This is called `/landusecategories` - will update the naming in a separate diff.

![parcel-dropdown](https://user-images.githubusercontent.com/4812055/37878469-8a0a3376-302f-11e8-8a86-6172ef1cbd78.gif)
