### PR TITLE
Set port to 4000 everywhere except production

### DIFF
--- a/frontend/src/client.js
+++ b/frontend/src/client.js
@@ -27,4 +27,8 @@ class ParcelApiClient {
   }
 }
 
-export default new ParcelApiClient('/api')
+const APIROOT = process.env.NODE_ENV === 'production'
+  ? ''
+  : 'http://localhost:4000'
+
+export default new ParcelApiClient(`${APIROOT}/api`)


### PR DESCRIPTION
This sets the API client port to 4000 everywhere except production.  The `process.env.NODE_ENV` is replaced by webpack with it's value during file processing, so can be used to change variables based on environments.