### PR TITLE
Deploy master to Heroku using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,33 @@
 language: elixir
-
 elixir:
-  - 1.6
-
+- 1.6
 otp_release:
-  - 20.2
-
+- 20.2
 addons:
-  postgresql: "9.6"
-
+  postgresql: '9.6'
 cache:
   directories:
-    - _build
-    - deps
-    - frontend/node_modules
-
+  - _build
+  - deps
+  - frontend/node_modules
 before_install:
-  # for e2e testing using Chrome and Selenium
-  # - export DISPLAY=:99.0
-  # - sh -e /etc/init.d/xvfb start
-  # install and use latest NodeJS LTS release
-  - nvm install --lts
-  - nvm use --lts
-  # install frontend dependencies
-  - cd frontend
-  - npm install
-  - cd ..
-
+- nvm install --lts
+- nvm use --lts
+- cd frontend
+- npm install
+- cd ..
 script:
-  # test backend
-  - mix test
-  # test frontend
-  - cd frontend
-  # disabling running e2e test for now, too flaky
-  # - npm run test
-  - npm run unit
-
+- mix test
+- cd frontend
+- npm run unit
 branches:
   only:
-    - master
-    - develop
+  - master
+  - develop
+deploy:
+  provider: heroku
+  api_key:
+    secure: YGWPwkEq+zEIqjLMl69rh7lK2tWMrbapLmUUDHMBr2G8qxWvMdI1UbO+v9LTi1Exms8uuWTEtZHj1Sv28rjxQ2N+dmYGppLoHvqIputMycq0bV26snFrelJRsOoMvYSzkzkO94sCxUOAAK5o2k8iis8bM6yHW8i3TZGhJYb62SqIFPQS/nkDs/9Z+G5p0SgDjJ009s5AB9Porp7qCqO2X2kkNsyLvruIjvAJEVnSS0jbFOfoUUYt2amAZtf16AWM3GHVRkJcgvleoWxcnxbRTKFlE58HADlXcpNyITrIAxWIWDOEBfZEh10x/5UaT6HGDJSPZRn9NncF03IQkrDR60bbYG/ZOnWH+SzbDxvtio0ngnmAmqLbcrp1NaSB6phBax6CJXkpcXT1koHfwhmg27ubCGJQxLnRzlehsFwgSPKrSmfXFfv3NawDKpJt4otyMKuxIQcbuYJ3wu9sXq275GKIjcS2M9U7jfFNnJZghvWD4aA2SQc4YbOXSm3nhBm8m54/xfYIX/L82GjbqqXFv4JO8a52r2V9Lrh1gUBwmE9EwXgIx2rYSayFxXcIMuDdxpBdGq+meX2EIH9NfINCB2zJs6ps+doX0aKr9hrOZx2hDc8oYlOZMhyU0X5w6+BYPxe5KMMFrM/n8SkXzPhTBgUpMU9dQeyoAUcKAG9NT6c=
+  app: parcel-nashville
+  # Migrations
+  run: mix ecto.migrate

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To test the frontend:
 `mix ecto.drop && mix ecto.setup && mix ecto.migrate`
 
 ## Heroku Deployment
-Follow the steps in [Phoenix's Heroku deployment](https://hexdocs.pm/phoenix/heroku.html#content) to generate your own deployment.
+This repository is configured to deploy master automatically to Heroku via Travis CI.
 
 ## Planning
 - For a detailed description of the project, check out the [Request for Volunteers](https://docs.google.com/document/d/17DNk0QQyi8SEK4utcMt3zT-Dc6vXzA_zcFwrEENvKJo/edit?usp=sharing).


### PR DESCRIPTION
This follows [these instructions](https://docs.travis-ci.com/user/deployment/heroku/) for configuring Travis CI to deploy to our heroku app - parcel-nashville.herokuapp.com - for new master builds.