### PR TITLE
Added Google Analytics in production.

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,6 +18,7 @@
     <% } %>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="google-site-verification" content="iLduelR9qGqpKOdqZ8y3vDet-8w5mTocNhPKmF0m9NM" />
     <title>Parcel</title>
     <link href="https://fonts.googleapis.com/css?family=Merriweather|Source+Sans+Pro" rel="stylesheet">
     <link rel="icon" type="image/png" href="/static/img/favicon.png">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,6 +1,21 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <% if (process.env.NODE_ENV === 'production') { %>
+    <!-- Lodash templates are available by default for html-webpack-plugin -->
+    <!-- Example usages here https://learn.co/lessons/javascript-lodash-templates -->
+    <!-- Global site tag (gtag.js) - Google Analytics, but only in production -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-116965240-1"></script>
+    <script>
+      if (process.env.NODE_ENV === 'production') {
+        window.dataLayer = window.dataLayer || []
+        function gtag () { dataLayer.push(arguments) }
+        gtag('js', new Date())
+
+        gtag('config', 'UA-116965240-1')
+      }
+    </script>
+    <% } %>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>Parcel</title>


### PR DESCRIPTION
By default, html-web-plugin processes the template using lodash templates. This takes advantage of this, only rendering HTML if the the node environment is set to production.

Closes #22.