### PR TITLE
Add detailed error codes on backend and error notification with messages on the frontend

### DIFF
--- a/frontend/src/client.js
+++ b/frontend/src/client.js
@@ -1,34 +1,16 @@
-import axios from 'axios'
+const APIROOT = process.env.NODE_ENV === 'production'
+  ? '/api'
+  : 'http://localhost:4000/api'
 
-class ParcelApiClient {
-  constructor (baseUrl) {
-    this.client = axios.create({
-      baseURL: baseUrl,
-      headers: {'Accept': 'application/json'},
-      timeout: 5000
-    })
-  }
-
-  getLandUseCategories () {
-    return this.client.get('/landusecategories')
-  }
-
-  /* /landuses/?address=My%20Addresss schema:
-  {
-    "zone": {"code", "category", "description"},
-    "land_uses": [
-      {"category", "name", "condition": {"code", "info_link", "description", "category"}}
-    ]
-  }
-
-  */
-  getLandUseSummaryForAddress (address) {
-    return this.client.get('/landuses', { params: { address } })
-  }
+function getLandUseCategories () {
+  return fetch(`${APIROOT}/landusecategories`)
 }
 
-const APIROOT = process.env.NODE_ENV === 'production'
-  ? ''
-  : 'http://localhost:4000'
+function getLandUseSummaryForAddress (address) {
+  return fetch(`${APIROOT}/landuses?address=${window.encodeURI(address)}`)
+}
 
-export default new ParcelApiClient(`${APIROOT}/api`)
+export default {
+  getLandUseCategories,
+  getLandUseSummaryForAddress
+}

--- a/frontend/src/components/ErrorNotification.vue
+++ b/frontend/src/components/ErrorNotification.vue
@@ -1,0 +1,21 @@
+<template>
+  <b-alert variant="danger" show>
+    {{message}} Contact the Metro Planning Department
+    at
+    <a class="alert-link" href="tel:+615-862-7190">615-862-7190</a>
+    or
+    <a class="alert-link" href="mailto:planningstaff@nashville.gov">planningstaff@nashville.gov</a>
+    for help resolving your zoning or land use question.
+  </b-alert>
+</template>
+
+<script>
+import bAlert from 'bootstrap-vue/es/components/alert/alert'
+
+export default {
+  components: {
+    bAlert
+  },
+  props: ['message']
+}
+</script>

--- a/lib/parcel/nashville_arcgis_api/client.ex
+++ b/lib/parcel/nashville_arcgis_api/client.ex
@@ -9,15 +9,20 @@ defmodule Parcel.NashvilleArcgisApi.Client do
   """
   @type point :: {float, float}
 
+  @typedoc """
+  An error consists of an Atom label, and a String message
+  """
+  @type error :: {Atom, String}
+
   @doc """
   Retrieve a geocode for a given Nashville address.
   """
-  @callback geocode_address(address :: String) :: {:ok, point} | {:error, String}
+  @callback geocode_address(address :: String) :: {:ok, point} | error
 
   @doc """
   Retrieve the short Zoning code for a geographic point in Nashville.
 
   For example, "MUI", "AG".
   """
-  @callback get_zone(point :: point) :: {:ok, String} | {:error, String}
+  @callback get_zone(point :: point) :: {:ok, String} | error
 end

--- a/lib/parcel/nashville_arcgis_api/http_client.ex
+++ b/lib/parcel/nashville_arcgis_api/http_client.ex
@@ -24,11 +24,11 @@ defmodule Parcel.NashvilleArcgisApi.HttpClient do
           point_map = address_match["location"]
           {:ok, {point_map["x"], point_map["y"]}}
         else
-          {:error, "No candidates returned"}
+          {:not_found, "No candidates returned"}
         end
 
       {:error, %HTTPoison.Error{reason: reason}} ->
-        {:error, "Server error #{reason}"}
+        {:error, "Error #{reason}"}
     end
   end
 

--- a/lib/parcel/zoning/zone_use.ex
+++ b/lib/parcel/zoning/zone_use.ex
@@ -38,40 +38,49 @@ defmodule Parcel.Zoning.ZoneLandUseCondition do
   def land_use_summary(address) do
     import Ecto.Query
 
-    {:ok, point} = @nashville_arc_gis_api.geocode_address(address)
-    {:ok, zone_code} = @nashville_arc_gis_api.get_zone(point)
-
-    # All land uses conditions where zone.code = zone_code
-    zone_land_uses =
-      from(
-        zone_land_use in ZoneLandUseCondition,
-        join: zone in Zone,
-        where: zone.id == zone_land_use.zone_id,
-        where: zone.code == ^zone_code,
-        preload: [:land_use, :land_use_condition]
-      )
-
-    zone = Repo.get_by!(Zone, code: zone_code)
-
-    %{
-      "zone" => %{
-        "code" => zone.code,
-        "description" => zone.description,
-        "category" => zone.category
-      },
-      "land_uses" =>
-        Enum.map(Repo.all(zone_land_uses), fn zone_land_use ->
-          %{
-            "category" => zone_land_use.land_use.category,
-            "name" => zone_land_use.land_use.name,
-            "condition" => %{
-              "code" => zone_land_use.land_use_condition.code,
-              "category" => zone_land_use.land_use_condition.category,
-              "description" => zone_land_use.land_use_condition.description,
-              "info_link" => zone_land_use.land_use_condition.info_link
-            }
-          }
-        end)
-    }
+    # :not_found
+    # :error
+    # :ok
+    with {:ok, point} <- @nashville_arc_gis_api.geocode_address(address),
+         # :error
+         # :ok
+         {:ok, zone_code} <- @nashville_arc_gis_api.get_zone(point),
+         # All land uses conditions where zone.code = zone_code
+         zone_land_uses <- from(
+           zone_land_use in ZoneLandUseCondition,
+           join: zone in Zone,
+           where: zone.id == zone_land_use.zone_id,
+           where: zone.code == ^zone_code,
+           preload: [:land_use, :land_use_condition]
+         ),
+         # if nil return {:unknown_zone, zone_code}
+         zone when not is_nil(zone) <- Repo.get_by(Zone, code: zone_code) do
+      {:ok, %{
+         "zone" => %{
+           "code" => zone.code,
+           "description" => zone.description,
+           "category" => zone.category
+         },
+         "land_uses" =>
+           Enum.map(Repo.all(zone_land_uses), fn zone_land_use ->
+             %{
+               "category" => zone_land_use.land_use.category,
+               "name" => zone_land_use.land_use.name,
+               "condition" => %{
+                 "code" => zone_land_use.land_use_condition.code,
+                 "category" => zone_land_use.land_use_condition.category,
+                 "description" => zone_land_use.land_use_condition.description,
+                 "info_link" => zone_land_use.land_use_condition.info_link
+               }
+             }
+           end)
+       }}
+    else
+      # is_nil(zone)
+      nil -> :unknown_zone
+      # address :not_found
+      {:not_found, _} -> :not_found
+      {:error, _} -> :error
+    end
   end
 end

--- a/lib/parcel_web/controllers/land_uses_controller.ex
+++ b/lib/parcel_web/controllers/land_uses_controller.ex
@@ -5,7 +5,15 @@ defmodule ParcelWeb.LandUsesController do
   action_fallback(ParcelWeb.FallbackController)
 
   def index(conn, %{"address" => address}) do
-    json(conn, ZoneLandUseCondition.land_use_summary(address))
+    case ZoneLandUseCondition.land_use_summary(address) do
+      {:ok, land_use_summary} -> json(conn, land_use_summary)
+      # Address not found
+      :not_found -> put_status(conn, 404)
+      # The Zone represents an unknown zone or sattelite city
+      :unknown_zone -> put_status(conn, 422)
+      # A random error
+      :error -> put_status(conn, 500)
+    end
   end
 
   def index(_conn, _params), do: {:error, :bad_request, "Missing address parameter."}

--- a/lib/parcel_web/controllers/land_uses_controller.ex
+++ b/lib/parcel_web/controllers/land_uses_controller.ex
@@ -8,11 +8,11 @@ defmodule ParcelWeb.LandUsesController do
     case ZoneLandUseCondition.land_use_summary(address) do
       {:ok, land_use_summary} -> json(conn, land_use_summary)
       # Address not found
-      :not_found -> put_status(conn, 404)
+      :not_found -> put_status(conn, 404) |> json(%{message: "We couldn't find an address matching \"#{address}\"."})
       # The Zone represents an unknown zone or sattelite city
-      :unknown_zone -> put_status(conn, 422)
+      :unknown_zone -> put_status(conn, 422) |> json(%{message: "We don't have zoning information available for \"#{address}\"."})
       # A random error
-      :error -> put_status(conn, 500)
+      :error -> put_status(conn, 500) |> json(%{message: "Unknown server error - please try again later."})
     end
   end
 

--- a/test/parcel_web/controllers/land_uses_controller_test.exs
+++ b/test/parcel_web/controllers/land_uses_controller_test.exs
@@ -83,4 +83,27 @@ defmodule ParcelWeb.LandUsesControllerTest do
 
     assert json_response(conn, 200) == expected
   end
+
+  test "Missing zones return a 422", %{conn: conn} do
+    MockClient
+    |> expect(:geocode_address, fn _ -> {:ok, {0, 0}} end)
+    # Deliberately don't put the zone in
+    |> expect(:get_zone, fn _ -> {:ok, "IR"} end)
+
+    conn =
+      get(conn, api_land_uses_path(conn, :index, address: "500 Interstate Blvd S, Suite 300"))
+
+    assert(conn.status == 422)
+  end
+
+  test "Unknown address return a 404", %{conn: conn} do
+    MockClient
+    # Return a not found
+    |> expect(:geocode_address, fn _ -> {:not_found, ""} end)
+
+    conn =
+      get(conn, api_land_uses_path(conn, :index, address: "500 Interstate Blvd S, Suite 300"))
+
+    assert(conn.status == 404)
+  end
 end


### PR DESCRIPTION
Add detailed error codes w/ corresponding HTTP statuses to the backend for zoning lookup. This includes:

* Address not found
* Unknown zones - right now the only thing I've run into locally is "Satellite Cities" - we might be able to special case and provide the user some actionable information here.
* Server/network errors

This adds a bootstrap danger alert to the frontend which displays a full sentence error message, along with contact information for Metro.

The alert isn't dismissible, because I haven't figured out how to bring back the component when the `errorMessage` is reset.

Closes #17 ,#18 