### PR TITLE
Set address in data so it has a value

### DIFF
--- a/frontend/src/components/ParcelHome.vue
+++ b/frontend/src/components/ParcelHome.vue
@@ -75,6 +75,7 @@
   export default {
     data () {
       return {
+        address: '',
         category: null,
         errorMessage: null,
         landUseCategories: [],


### PR DESCRIPTION
Closes #69.  `ParcelHome.address` was value-less until the user typed into the search.  This adds an initial state as an empty string to avoid the runtime error reported in the bug.